### PR TITLE
Enable install.sh CI testing 

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -133,39 +133,38 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-# TODO: this can be re-enabled after the first release in the docker org
-#      - uses: actions/download-artifact@v2
-#        with:
-#          name: artifacts
-#          path: snapshot
-#
-#      - name: Build key for image cache
-#        run: make install-fingerprint
-#
-#      - name: Restore install.sh test image cache
-#        id: install-test-image-cache
-#        uses: actions/cache@v2.1.3
-#        with:
-#          path: ${{ github.workspace }}/test/install/cache
-#          key: ${{ runner.os }}-install-test-image-cache-${{ hashFiles('test/install/cache.fingerprint') }}
-#
-#      - name: Restore tool cache
-#        id: tool-cache
-#        uses: actions/cache@v2.1.3
-#        with:
-#          path: ${{ github.workspace }}/.tmp
-#          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
-#
-#      - name: Load test image cache
-#        if: steps.install-test-image-cache.outputs.cache-hit == 'true'
-#        run: make install-test-cache-load
-#
-#      - name: Run install.sh tests (Linux)
-#        run: make install-test
-#
-#      - name: (cache-miss) Create test image cache
-#        if: steps.install-test-image-cache.outputs.cache-hit != 'true'
-#        run: make install-test-cache-save
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: snapshot
+
+      - name: Build key for image cache
+        run: make install-fingerprint
+
+      - name: Restore install.sh test image cache
+        id: install-test-image-cache
+        uses: actions/cache@v2.1.3
+        with:
+          path: ${{ github.workspace }}/test/install/cache
+          key: ${{ runner.os }}-install-test-image-cache-${{ hashFiles('test/install/cache.fingerprint') }}
+
+      - name: Restore tool cache
+        id: tool-cache
+        uses: actions/cache@v2.1.3
+        with:
+          path: ${{ github.workspace }}/.tmp
+          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+
+      - name: Load test image cache
+        if: steps.install-test-image-cache.outputs.cache-hit == 'true'
+        run: make install-test-cache-load
+
+      - name: Run install.sh tests (Linux)
+        run: make install-test
+
+      - name: (cache-miss) Create test image cache
+        if: steps.install-test-image-cache.outputs.cache-hit != 'true'
+        run: make install-test-cache-save
 
   Acceptance-Mac:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
@@ -185,9 +184,8 @@ jobs:
           brew install docker
           mkdir ~/.docker
 
-# TODO: put back in after the first release
-#      - name: Run install.sh tests (Mac)
-#        run: make install-test-ci-mac
+      - name: Run install.sh tests (Mac)
+        run: make install-test-ci-mac
 
   Cli-Linux:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# docker-sbom-cli-plugin
+# sbom-cli-plugin
 
-Plugin for Docker CLI to support SBOM creation using Syft.
+Plugin for Docker CLI to support viewing and creating SBOMs for Docker images using Syft.
 
 **Note: this is a proof of concept / work in progress**
 

--- a/test/install/Makefile
+++ b/test/install/Makefile
@@ -12,7 +12,7 @@ UNIT=make unit-local
 # acceptance testing is running the current install.sh against the latest release. Note: this could be a problem down
 # the line if there are breaking changes made that don't align with the latest release (but will be OK with the next
 # release)
-ACCEPTANCE_CMD=sh -c '../../install.sh -b /usr/local/bin  && docker sbom version'
+ACCEPTANCE_CMD=sh -c '../../install.sh && docker sbom version'
 
 # CI cache busting values; change these if you want CI to not use previous stored cache
 INSTALL_TEST_CACHE_BUSTER=894d8ca


### PR DESCRIPTION
Now that v0.4.0 has been released in the docker org 🎉 this PR enables CI testing for install.sh