### PR TITLE
Upgrade to syft v0.43.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.18
 require (
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
-	github.com/anchore/stereoscope v0.0.0-20220330151554-fccf0ee7be68
-	github.com/anchore/syft v0.42.2
+	github.com/anchore/stereoscope v0.0.0-20220330165332-7fc73ee7b0f0
+	github.com/anchore/syft v0.43.0
 	github.com/containerd/containerd v1.5.10 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect
 	github.com/docker/cli v20.10.12+incompatible

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
-	github.com/anchore/stereoscope v0.0.0-20220322123031-7a744f443e99
+	github.com/anchore/stereoscope v0.0.0-20220329150647-be0d56bc0917
 	github.com/anchore/syft v0.42.2
 	github.com/containerd/containerd v1.5.10 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect
@@ -104,7 +104,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/scylladb/go-set v1.0.2 // indirect
+	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
 	github.com/spdx/tools-golang v0.2.0 // indirect
 	github.com/spf13/afero v1.8.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
-	github.com/anchore/stereoscope v0.0.0-20220329150647-be0d56bc0917
+	github.com/anchore/stereoscope v0.0.0-20220330151554-fccf0ee7be68
 	github.com/anchore/syft v0.42.2
 	github.com/containerd/containerd v1.5.10 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b h1:YJWYt/6KQXR9JR46lLHrTTYi8rcye42tKcyjREA/hvA=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
-github.com/anchore/stereoscope v0.0.0-20220322123031-7a744f443e99 h1:npngzwfM+fmA56VslKxrcKNhGa2W8MMnASQ1CpuZ1ZA=
-github.com/anchore/stereoscope v0.0.0-20220322123031-7a744f443e99/go.mod h1:By2EeOMx9BCf44Wu92W/gsarFKB2Yj921IANAw2Pj1k=
+github.com/anchore/stereoscope v0.0.0-20220329150647-be0d56bc0917 h1:tFHnZHgMQhW4j6HtHEIIkD4TpKFgGy0faGrSpc55Rc8=
+github.com/anchore/stereoscope v0.0.0-20220329150647-be0d56bc0917/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
 github.com/anchore/syft v0.42.2 h1:mP19PsNYhCUXvYTDNtpuV5SRIRwpgtbKSUrbX+CWKn0=
 github.com/anchore/syft v0.42.2/go.mod h1:OA3VoQ416NEo2trKi44g/eb0at8BN15746GKIIUFNlI=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -1148,8 +1148,8 @@ github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43
 github.com/sanposhiho/wastedassign/v2 v2.0.6/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dmsbF2ud9pAAGfoLfjhtI=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
-github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
-github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvvtIRwBrU/aegEYJYmvev0cHAwo17zZQ=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec/v2 v2.9.1/go.mod h1:oDcDLcatOJxkCGaCaq8lua1jTnYf6Sou4wdiJ1n4iHc=

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,10 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b h1:YJWYt/6KQXR9JR46lLHrTTYi8rcye42tKcyjREA/hvA=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
-github.com/anchore/stereoscope v0.0.0-20220330151554-fccf0ee7be68 h1:y2J0i6804DJ2H+4bBTyyiu9ZZtXay5Cn17RU+pAAGH4=
-github.com/anchore/stereoscope v0.0.0-20220330151554-fccf0ee7be68/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
-github.com/anchore/syft v0.42.2 h1:mP19PsNYhCUXvYTDNtpuV5SRIRwpgtbKSUrbX+CWKn0=
-github.com/anchore/syft v0.42.2/go.mod h1:OA3VoQ416NEo2trKi44g/eb0at8BN15746GKIIUFNlI=
+github.com/anchore/stereoscope v0.0.0-20220330165332-7fc73ee7b0f0 h1:mObz7bepZ6DtbIrsB2mxuOE9XEYmVtA/P/EDlKwfbjs=
+github.com/anchore/stereoscope v0.0.0-20220330165332-7fc73ee7b0f0/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
+github.com/anchore/syft v0.43.0 h1:9w52VCgSutRL08ojztoXwG6/KdOjS3w+5ePZqJNGx5o=
+github.com/anchore/syft v0.43.0/go.mod h1:Po6PO927XnrHzrs8qshOjAfb/wBmu4cXEeO7FmlWFgk=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b h1:YJWYt/6KQXR9JR46lLHrTTYi8rcye42tKcyjREA/hvA=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
-github.com/anchore/stereoscope v0.0.0-20220329150647-be0d56bc0917 h1:tFHnZHgMQhW4j6HtHEIIkD4TpKFgGy0faGrSpc55Rc8=
-github.com/anchore/stereoscope v0.0.0-20220329150647-be0d56bc0917/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
+github.com/anchore/stereoscope v0.0.0-20220330151554-fccf0ee7be68 h1:y2J0i6804DJ2H+4bBTyyiu9ZZtXay5Cn17RU+pAAGH4=
+github.com/anchore/stereoscope v0.0.0-20220330151554-fccf0ee7be68/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
 github.com/anchore/syft v0.42.2 h1:mP19PsNYhCUXvYTDNtpuV5SRIRwpgtbKSUrbX+CWKn0=
 github.com/anchore/syft v0.42.2/go.mod h1:OA3VoQ416NEo2trKi44g/eb0at8BN15746GKIIUFNlI=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/test/cli/sbom_cmd_test.go
+++ b/test/cli/sbom_cmd_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSBOMCmdFlags(t *testing.T) {
+	hiddenPackagesImage := getFixtureImage(t, "image-hidden-packages")
 	coverageImage := getFixtureImage(t, "image-pkg-coverage")
 	tmp := t.TempDir() + "/"
 
@@ -78,17 +79,21 @@ func TestSBOMCmdFlags(t *testing.T) {
 		},
 		{
 			name: "squashed-scope-flag",
-			args: []string{"sbom", "--format", "json", "--layers", "squashed", coverageImage},
+			args: []string{"sbom", "--format", "json", "--layers", "squashed", hiddenPackagesImage},
 			assertions: []traitAssertion{
-				assertPackageCount(20),
+				assertPackageCount(162),
+				assertInOutput("squashed"),
+				assertNotInOutput("vsftpd"), // hidden package
 				assertSuccessfulReturnCode,
 			},
 		},
 		{
 			name: "all-layers-scope-flag",
-			args: []string{"sbom", "--format", "json", "--layers", "all-layers", coverageImage},
+			args: []string{"sbom", "--format", "json", "--layers", "all-layers", hiddenPackagesImage},
 			assertions: []traitAssertion{
-				assertPackageCount(22),
+				assertPackageCount(163),
+				assertInOutput("all-layers"),
+				assertInOutput("vsftpd"), // hidden package
 				assertSuccessfulReturnCode,
 			},
 		},

--- a/test/cli/sbom_cmd_test.go
+++ b/test/cli/sbom_cmd_test.go
@@ -35,7 +35,7 @@ func TestSBOMCmdFlags(t *testing.T) {
 				assertInOutput("docker-sbom ("),
 				assertInOutput("Provider:"),
 				assertInOutput("GitDescription:"),
-				assertInOutput("syft (v0.42.2)"),
+				assertInOutput("syft (v0.43.0)"),
 				assertNotInOutput("not provided"),
 				assertSuccessfulReturnCode,
 			},
@@ -55,7 +55,7 @@ func TestSBOMCmdFlags(t *testing.T) {
 			args: []string{"sbom", "--format", "json", coverageImage},
 			assertions: []traitAssertion{
 				assertJsonReport,
-				assertJsonDescriptor(internal.SyftName, "v0.42.2"),
+				assertJsonDescriptor(internal.SyftName, "v0.43.0"),
 				assertNotInOutput("not provided"),
 				assertSuccessfulReturnCode,
 			},

--- a/test/cli/test-fixtures/image-hidden-packages/Dockerfile
+++ b/test/cli/test-fixtures/image-hidden-packages/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:7.9.2009
+# all-layers scope should pickup on vsftpd
+RUN yum install -y vsftpd
+RUN yum remove -y vsftpd


### PR DESCRIPTION
Incorporates syft `v0.43.0` which accomplishes a couple things:
- Adds dart support
- Fixes docker auth config during image pulls (https://github.com/anchore/stereoscope/pull/120)
- Deduplicates identical packages found across multiple layers 