### PR TITLE
Add github format alias

### DIFF
--- a/cmd/format_aliases.go
+++ b/cmd/format_aliases.go
@@ -22,6 +22,8 @@ func formatAliases(ids ...sbom.FormatID) (aliases []string) {
 			aliases = append(aliases, "cyclonedx-xml")
 		case syft.CycloneDxJSONFormatID:
 			aliases = append(aliases, "cyclonedx-json")
+		case syft.GitHubID:
+			aliases = append(aliases, "github-json")
 		default:
 			aliases = append(aliases, string(id))
 		}


### PR DESCRIPTION
Currently the github dependency graph API SBOM format name is `github-0-json`, this PR adjusts the name to `github-json`.