### PR TITLE
Retry auth URL lookup without docker credentialhelper workaround

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.18
 require (
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
-	github.com/anchore/stereoscope v0.0.0-20220330165332-7fc73ee7b0f0
-	github.com/anchore/syft v0.43.0
+	github.com/anchore/stereoscope v0.0.0-20220406160859-c03a18a6b270
+	github.com/anchore/syft v0.43.2
 	github.com/containerd/containerd v1.5.10 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect
 	github.com/docker/cli v20.10.12+incompatible

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,10 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b h1:YJWYt/6KQXR9JR46lLHrTTYi8rcye42tKcyjREA/hvA=
 github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
-github.com/anchore/stereoscope v0.0.0-20220330165332-7fc73ee7b0f0 h1:mObz7bepZ6DtbIrsB2mxuOE9XEYmVtA/P/EDlKwfbjs=
-github.com/anchore/stereoscope v0.0.0-20220330165332-7fc73ee7b0f0/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
-github.com/anchore/syft v0.43.0 h1:9w52VCgSutRL08ojztoXwG6/KdOjS3w+5ePZqJNGx5o=
-github.com/anchore/syft v0.43.0/go.mod h1:Po6PO927XnrHzrs8qshOjAfb/wBmu4cXEeO7FmlWFgk=
+github.com/anchore/stereoscope v0.0.0-20220406160859-c03a18a6b270 h1:NmxPDR6vo3xjwCL6o+tpF1vUad/BVo+WaVSwueB9W9w=
+github.com/anchore/stereoscope v0.0.0-20220406160859-c03a18a6b270/go.mod h1:yoCLUZY0k/pYLNIy0L80p2Ko0PKVNXm8rHtgxp4OiSc=
+github.com/anchore/syft v0.43.2 h1:VkC/gZVpVcE1B/E80XP73z9u2f7865l6WBdpKZakHhs=
+github.com/anchore/syft v0.43.2/go.mod h1:m6/cWOz0aFbCL0pflHvvBgvw0qMPLVqDQa0L8+FBPVE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=

--- a/test/cli/sbom_cmd_test.go
+++ b/test/cli/sbom_cmd_test.go
@@ -36,7 +36,7 @@ func TestSBOMCmdFlags(t *testing.T) {
 				assertInOutput("docker-sbom ("),
 				assertInOutput("Provider:"),
 				assertInOutput("GitDescription:"),
-				assertInOutput("syft (v0.43.0)"),
+				assertInOutput("syft (v0.43.2)"),
 				assertNotInOutput("not provided"),
 				assertSuccessfulReturnCode,
 			},
@@ -56,7 +56,7 @@ func TestSBOMCmdFlags(t *testing.T) {
 			args: []string{"sbom", "--format", "json", coverageImage},
 			assertions: []traitAssertion{
 				assertJsonReport,
-				assertJsonDescriptor(internal.SyftName, "v0.43.0"),
+				assertJsonDescriptor(internal.SyftName, "v0.43.2"),
 				assertNotInOutput("not provided"),
 				assertSuccessfulReturnCode,
 			},


### PR DESCRIPTION
Pulls in the fix described in https://github.com/anchore/syft/issues/936 and fixed in https://github.com/anchore/stereoscope/pull/122 .