### PR TITLE
Remove the root of all temp files on shutdown

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -258,15 +258,17 @@ func sbomExecWorker(imageName string, dockerCli command.Cli, platform *image.Pla
 	go func() {
 		defer close(errs)
 
+		tempGen := file.NewTempDirGenerator(internal.ApplicationName)
+
 		provider := stereoscopeDocker.NewProviderFromDaemon(
 			imageName,
-			file.NewTempDirGenerator(internal.ApplicationName),
+			tempGen,
 			dockerCli.Client(),
 			platform,
 		)
 		img, err := provider.Provide(context.Background())
 		defer func() {
-			if err := img.Cleanup(); err != nil {
+			if err := tempGen.Cleanup(); err != nil {
 				log.Warnf("failed to clean up image: %+v", err)
 			}
 		}()


### PR DESCRIPTION
The stereoscope docker daemon provider uses the docker tarball provider, each provider is creating sibling temp directories within a single common temp directory. The issue issue is that the daemon provider saves the image tar in one temp dir while the tarball providers unarchives the image tar within another (sibling) temp dir. The image is being created off of the tarball provider has no visibility into the temp files created by the other provider.

This workaround uses the temp-dir-generator as a source for deleting the root temp directory.

Opened issue in upstream: https://github.com/anchore/stereoscope/issues/132 (the docker daemon provider should take care of this problem directly so that `image.Cleanup()` functions correctly)

Fixes #22 