### PR TITLE
Improve docker check in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -640,7 +640,7 @@ main() (
   tag=$1
 
   if [ "${install_dir}" = "${DEFAULT_INSTALL_DIR}" ]; then
-    if [ ! -d "${DOCKER_HOME}" ]; then
+    if [ ! -d "${DOCKER_HOME}" ] && ! which docker > /dev/null 2>&1; then
       log_err "docker is not installed; refusing to install to '${install_dir}'"
       exit 1
     fi


### PR DESCRIPTION
If found that the install script was not running in the `docker:stable` docker container unless I created the directory `~/.docker` manually, which does not exist by default. I thought it would be better than instead of just checking for this directory, to also check if the docker command is available before giving up on trying to install.