### PR TITLE
Updating golangci-lint to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(RESULTS_DIR):
 bootstrap-tools:
 	$(call title,Bootstrapping tools)
 	mkdir -p $(TEMP_DIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ v1.45.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ v1.50.1
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMP_DIR)/ v0.3.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMP_DIR)/ v0.4.1
 	.github/scripts/goreleaser-install.sh -b $(TEMP_DIR)/ v1.5.0


### PR DESCRIPTION
Upping from 1.45.0 to 1.50.1 to avoid panic

Linked issue -  [golangci-lint 1.45.0 - as referenced in Makefile - panics #29](https://github.com/docker/sbom-cli-plugin/issues/29)

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>