### PR TITLE
Fix linting and bouncer issues

### DIFF
--- a/.bouncer.yaml
+++ b/.bouncer.yaml
@@ -20,3 +20,4 @@ ignore-packages:
   # All these files have been put into the public domain.
   # You can do whatever you want with these files.
   - github.com/xi2/xz
+  - crypto/internal/boring

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(RESULTS_DIR):
 bootstrap-tools:
 	$(call title,Bootstrapping tools)
 	mkdir -p $(TEMP_DIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ v1.45.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ v1.50.1
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMP_DIR)/ v0.3.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMP_DIR)/ v0.4.1
 	.github/scripts/goreleaser-install.sh -b $(TEMP_DIR)/ v1.5.0

--- a/cmd/event_loop.go
+++ b/cmd/event_loop.go
@@ -14,7 +14,8 @@ import (
 // eventLoop listens to worker errors (from execution path), worker events (from a partybus subscription), and
 // signal interrupts. Is responsible for handling each event relative to a given UI an to coordinate eventing until
 // an eventual graceful exit.
-// nolint:funlen
+//
+//nolint:funlen
 func eventLoop(workerErrs <-chan error, signals <-chan os.Signal, subscription *partybus.Subscription, cleanupFn func(), uxs ...ui.UI) error {
 	defer cleanupFn()
 	events := subscription.Events()

--- a/internal/logger/logrus.go
+++ b/internal/logger/logrus.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -58,7 +57,7 @@ func NewLogrusLogger(cfg LogrusConfig) *LogrusLogger {
 		}
 		output = logFile
 	default:
-		output = ioutil.Discard
+		output = io.Discard
 	}
 
 	appLogger.SetOutput(output)


### PR DESCRIPTION
Resolving a few linting and bouncer issues

- Updated internal/logger/logrus.go to handle ioutil deprecation
- Updated cmd/event_loop.go to handle linting issues
- Updated .bouncer.yaml to ignore crypto/internal/boring

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>